### PR TITLE
Fix issue with pixels array index on some ratios

### DIFF
--- a/ImageBlurhash.module.php
+++ b/ImageBlurhash.module.php
@@ -90,14 +90,14 @@ class ImageBlurhash extends InputfieldImage implements Module
         $blankFallbackGif = "data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==";
         $rawBlurhash = $this->getRawBlurhash($image);
         if ($rawBlurhash && $width > 0 && $height > 0) {
-            
-            $width = floor($width);
-            $height = floor($height);
 
             $ratio =  $width / $height;
             $calcWidth = 200;
             $calcWidth = ($width > $calcWidth) ? $calcWidth : $width;
             $calcHeight = $calcWidth / $ratio;
+            
+            $calcWidth = floor($calcWidth);
+            $calcHeight = floor($calcHeight);
 
             try {
                 $pixels = Blurhash::decode($rawBlurhash, $calcWidth, $calcHeight);


### PR DESCRIPTION
I've stumbled upon some errors when dealing with some ratios, (ex.: `->getBlurhashDataUri(500, 134)` would fail), seems like the `floor()` should be done after calculations to solve this.